### PR TITLE
Explicitly fail the build if DLLInject dies

### DIFF
--- a/postbuild/srvmgr.bat
+++ b/postbuild/srvmgr.bat
@@ -24,7 +24,14 @@ for /f %%A in (srvlist.txt) do call p patches\%%A a2server.exe
 
 call log adding srvmgr...
 rem add_dll a2server.exe srvmgr.dll server.mp >nul
+
 DLLInject server.dis
+
+if NOT %ERRORLEVEL% == 0 (
+	call log DLLInject has failed with error code %ERRORLEVEL%
+	pause
+	exit 1
+)
 
 del /Q /F release
 mkdir release
@@ -48,5 +55,5 @@ move /Y world.res release >nul
 move /Y srvmgr.pdb release >nul
 
 call log done!
-rem pause
+pause
 exit


### PR DESCRIPTION
Windows is fun --- it doesn't actually fail the build. But at least it says that it failed and stops the build process.