### PR TITLE
Give players the ability to filter quests in the inn

### DIFF
--- a/config_new.cpp
+++ b/config_new.cpp
@@ -168,7 +168,7 @@ namespace Config
     bool AllowOnlyOneQuest_KillNMonsters = false;
     bool AllowOnlyOneQuest_KillTheMonster = false;
     bool AllowOnlyOneQuest_KillTheGroup = false;
-
+	bool AllowQuestFilters = false;
 }
 
 int32_t ReadIntegerParameter(std::string value, int32_t MinValue, int32_t MaxValue)
@@ -591,6 +591,11 @@ int ReadConfig(const char* filename)
                     if(!CheckBool(value)) return lnid;
                     Config::AllowOnlyOneQuest_KillTheGroup = StrToBool(value);
                 }
+				else if(parameter == ToLower("AllowQuestFilters"))
+				{
+                    if(!CheckBool(value)) return lnid;
+                    Config::AllowQuestFilters = StrToBool(value);
+				}
                 else if(parameter == "servercaps")
                 {
                     value = Trim(ToLower(value));

--- a/config_new.h
+++ b/config_new.h
@@ -76,6 +76,7 @@ namespace Config
     extern bool AllowOnlyOneQuest_KillNMonsters;
     extern bool AllowOnlyOneQuest_KillTheMonster;
     extern bool AllowOnlyOneQuest_KillTheGroup;
+	extern bool AllowQuestFilters;
 
     extern std::string IPAddress;
     extern uint16_t IPAddressP;

--- a/inn.cpp
+++ b/inn.cpp
@@ -2,6 +2,7 @@
 #include <unordered_set>
 
 #include "lib/utils.hpp"
+#include "quests.h"
 
 // A couple data types used in the inn logic.
 namespace {
@@ -162,4 +163,34 @@ int __fastcall change_inn_reward_mob(GameDataRes *data, int unused, int target_e
 	}
 
 	return target_mob;
+}
+
+void InitializeMobNames() {
+	if (mob_names.get() != nullptr) {
+		return;
+	}
+
+	std::unique_ptr<std::unordered_map<int, std::string>> new_mob_names(new std::unordered_map<int, std::string>());
+
+	const GameDataRes* data = (GameDataRes*)0x6d0668;
+	const Array<MonsterInfo>& monsters = data->monsters;
+
+	for (int i = 0; i < monsters.size; ++i) {
+		const MonsterInfo& m = monsters.data[i];
+		if (m.monsterData.data == nullptr) {
+			continue;
+		}
+
+		const MonsterInfoData& d = *m.monsterData.data;
+
+		const int mob_type = d.face << 8 | d.typeId;
+
+		(*new_mob_names)[mob_type] = ToLower(m.name);
+	}
+	
+	if (mob_names.get() != nullptr) {
+		return;
+	}
+
+	mob_names = std::move(new_mob_names);
 }

--- a/quests.h
+++ b/quests.h
@@ -1,0 +1,17 @@
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+// Map of "mob type" to lowercase mob name. Mob type is: `face << 8 | type_id`.
+// This format is used by the "kill N monsters" quests.
+extern std::unique_ptr<std::unordered_map<int, std::string>> mob_names;
+
+// Initializes `mob_names`. Defined in `inn.cpp` because it has the necessary structures.
+// If `mob_names` are already initialized, does nothing.
+void InitializeMobNames();
+
+// Quest filter. Player ID -> filter string.
+extern std::unordered_map<short, std::string> quest_filter_per_player;
+
+// Initializes `quest_filter_per_player` by pre-allocating all possible player IDs.
+void InitializeQuestFilter();

--- a/srvmgr.cpp
+++ b/srvmgr.cpp
@@ -19,6 +19,7 @@
 #include "lib\socket.hpp"
 #include "srvmgr_new.h"
 #include "player_info.h"
+#include "quests.h"
 #include "zxmgr.h"
 
 /// CDECL нет очистки стека функцией
@@ -2861,6 +2862,9 @@ BOOL APIENTRY DllMain(HINSTANCE hModule, DWORD ul_reason_for_call, LPVOID lpRese
             log_format("Error: couldn't initialize ItemEx plugin.\n");
             return FALSE;
         }*/
+
+		// Initialize stuff for quest filtering.
+		InitializeQuestFilter();
 
         break;
     case DLL_PROCESS_DETACH:

--- a/srvmgr.vcxproj
+++ b/srvmgr.vcxproj
@@ -132,6 +132,7 @@
     <ClInclude Include="player_info.h" />
     <ClInclude Include="protolayer_hat.h" />
     <ClInclude Include="pvm2.h" />
+    <ClInclude Include="quests.h" />
     <ClInclude Include="scanrange.h" />
     <ClInclude Include="screenshots.h" />
     <ClInclude Include="shared.h" />

--- a/srvmgr.vcxproj.filters
+++ b/srvmgr.vcxproj.filters
@@ -248,6 +248,9 @@
     <ClInclude Include="this_call.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="quests.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="postbuild\arena.txt" />


### PR DESCRIPTION
Only first three quests are customizable (kill N monsters of type, kill specific unit, kill specific group). User selects a filter with `#quest FILTER` and all mobs with their names including FILTER (case-insensitive) will be shown. The group quests are filtered by the displayed monster.