### PR TITLE
Add VS Code + CMake build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ postbuild/release
 /postbuild/tmp_world/
 postbuild/world/data.xml
 postbuild/_data/world.res
+
+CMakeFiles/*
+*.cmake
+*.code-workspace
+build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,74 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(srvmgr)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+link_libraries(ws2_32)
+
+add_library(srvmgr SHARED srvmgr.def
+    a2server_utils.cpp
+    antiinvis.cpp
+    asm_unit_info.cpp
+    charcheck.cpp
+    cheat_codes.cpp
+    cheat_codes_new.cpp
+    common_new.cpp
+    config_new.cpp
+    crash_filter.cpp
+    crash_fixes.cpp
+    crashes_new.cpp
+    CRC_32.cpp
+    ctl_handle.cpp
+    distance_bug.cpp
+    File.cpp
+    forbidden_items.cpp
+    inn.cpp
+    itemex.cpp
+    magic_resist_limits.cpp
+    map_rotation.cpp
+    multiplayer_shop.cpp
+    partial_drop.cpp
+    pktmgr.cpp
+    player_info.cpp
+    protolayer_hat.cpp
+    pvm2.cpp
+    scanrange.cpp
+    scanrange_check.cpp
+    screenshots.cpp
+    shared.cpp
+    shops.cpp
+    spell_duration_fix.cpp
+    srvmgr.cpp
+    srvmgr_new.cpp
+    this_call.cpp
+    quests.cpp
+    unit_info.cpp
+    utils.cpp
+    zxmgr.cpp
+    lib/hat2.cpp
+    lib/packet.cpp
+    lib/ScanrangeCalc.cpp
+    lib/serialize.cpp
+    lib/socket.cpp
+    lib/utils.cpp
+)
+
+# Static link.
+set(CMAKE_FIND_LIBRARY_SUFFIXES ".lib")
+target_compile_options(srvmgr PUBLIC /MT)
+target_link_options(srvmgr PUBLIC /NODEFAULTLIB:MSVCRT)
+
+# Postbuild commands.
+add_custom_command(TARGET srvmgr
+    POST_BUILD
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMAND copy build\\Release\\srvmgr.dll postbuild
+)
+
+add_custom_command(TARGET srvmgr
+    POST_BUILD
+    COMMAND cmd /c ${CMAKE_CURRENT_SOURCE_DIR}/postbuild/srvmgr.bat
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/postbuild
+)

--- a/README.md
+++ b/README.md
@@ -4,3 +4,13 @@ srvmgr
 Edit data file (spells, items etc) there:
 
 \postbuild\world\data.xml
+
+## How to build in VS Code
+
+1. Install VS Code
+2. Install MSVC Build Tools
+3. In VS Code, install extensions: "C/C++" and "CMake"
+4. Go to CMake menu on the left, Project Status -> Configure -> Kit: select x86 version of the MSVC Build Tools
+5. Run "CMake: Configure" and "CMake: Build" from the top menu
+6. If DLLInject.exe fails to run, build one yourself from github.com/igroglaz/DLLInject
+7. The built a2serv.exe and srvmgr.dll will be in "postbuild/release/"

--- a/inn.cpp
+++ b/inn.cpp
@@ -103,7 +103,7 @@ struct GameDataRes {
 // `__fastcall` convention: last two arguments are passed in ECX and EDX, the rest on the stack.
 //
 // Note that `target_experience` is around reward (in gold) divided by 16.
-int __fastcall change_inn_reward_mob(GameDataRes *data, int unused, int target_experience) {
+extern "C" int __fastcall change_inn_reward_mob(GameDataRes *data, int unused, int target_experience) {
 	// Original logic:
 	//   1) Take all mobs with 63 < `typeId` < 99
 	//   2) exclude Ghost.1, F_Zombie.1 and F_Skeleton.1 by `face`

--- a/partial_drop.cpp
+++ b/partial_drop.cpp
@@ -64,10 +64,6 @@ float limit(float n, float lo, float hi)
         return hi;
     return n;
 }
-int round(float a)
-{
-    return (int)(a+0.5f);
-}
 int getDropNum(int num, float probability)
 {
         int dropN = 0;
@@ -85,7 +81,7 @@ int getDropNum(int num, float probability)
             else
             {
                 float odds = limit(rnd_gaussian(probability, 0.1), 0, 1);
-                dropN = round(odds * num);
+                dropN = (int)round(odds * num);
             }
         }
         return dropN;

--- a/postbuild/arena.txt
+++ b/postbuild/arena.txt
@@ -1,4 +1,3 @@
-rem SRV_CR11.xck
 SRV_ADM1.xck
 srv_dbg1.xck
 

--- a/postbuild/srvlist.txt
+++ b/postbuild/srvlist.txt
@@ -10,9 +10,7 @@ SRV_MAG.xck
 SRV_MAXP.xck
 SRV_POD.xck
 srv_pvm.xck
-rem SRV_UPD0.xck
 srv_drop.xck
-srv_quest_no_mail.xck
 srv_range.fc
 turn_off_random_bag.xck
 quest_availability.xck

--- a/zxmgr.h
+++ b/zxmgr.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <string>
 #include <vector>
+
 #include "syslib.h"
 
 #define PLAYER_FLAG_AI 1


### PR DESCRIPTION
Also cleaning up a bit to make it compile:

1.  Remove entries in `arena.txt` and `srvlist.txt` that start with `rem`. `rem` doesn't work there, it just produces an error "file rem doesn't exist" and fails post-build rule.
2.  Remove failing `srv_quest_no_mail.xck`.
3.  Remove `round()` function which clashes with the stdlib function.
4.  Add missing include `<string>` to `zxmgr.h` so that it can be compiled independently from other files.
5.  Add `extern "C"` so that linker can find the function. No idea.

Tested locally on Win11: compiles, executes post-build successfully. Doesn't run on my host system, but the built a2serv.exe + srvmgr.dll runs in a virtual machine.