### PR TITLE
Don't set current server directory to the client installation directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(srvmgr SHARED srvmgr.def
     spell_duration_fix.cpp
     srvmgr.cpp
     srvmgr_new.cpp
+    startup.cpp
     this_call.cpp
     quests.cpp
     unit_info.cpp

--- a/postbuild/server.dis
+++ b/postbuild/server.dis
@@ -236,6 +236,8 @@ JMP quest_change_kill_n_count 00562996
 
 ///////// jmp, 1: call
 
+// Don't `cd` to the installation directory of the client. It doesn't make sense for the server.
+JMP overwrite_current_directory 00482687
 
 // stuff removed from this file by ZZYZX (?). Putting it to the end to make changes list compatible:
 //JMP area_cast 5054FF /// log area_casts - ���������������

--- a/srvmgr.cpp
+++ b/srvmgr.cpp
@@ -440,7 +440,6 @@ void __declspec(naked) check_health()
     }
 }
 
-
 // Function to return a simple random-like value based on the current time
 int GetCurrentTimeModulo()
 {

--- a/srvmgr.def
+++ b/srvmgr.def
@@ -177,3 +177,4 @@ disable_mage_scrolls              		@313
 change_inn_reward_mob                   @314
 check_health                            @315
 quest_change_kill_n_count				@316
+overwrite_current_directory             @317

--- a/startup.cpp
+++ b/startup.cpp
@@ -1,0 +1,10 @@
+// Original server sets the current directory to the client installation
+// directory (by reading "HKLM\SOFTWARE\1C\Allods 2\INSTALLDIR"). We remove
+// this odd logic to allow multiple independent servers to be run.
+extern "C" void __declspec(naked) overwrite_current_directory() {
+    // For some reason, CALL didn't work. So we make a JMP and then jump back.
+    __asm {
+        mov edx, 0x0048269b
+        jmp edx
+    }
+}


### PR DESCRIPTION
I tried doing a `CALL` but it didn't work for some reason, so I'm resorting to `JMP` and a jump back.