### PR TITLE
Fix quest filters being applied to other players

### DIFF
--- a/cheat_codes_new.cpp
+++ b/cheat_codes_new.cpp
@@ -211,6 +211,7 @@ void ProcessCheat_Quest(byte* player, const std::string& args) {
 
 	player_settings[player_id]->quest_filter = filter;
 	player_settings[player_id]->quest_mob_count = mob_count;
+    player_settings[player_id]->player_name = p->name;
 
 	if (filter.length() > 0) {
 		if (mob_count > 0) {

--- a/quests.cpp
+++ b/quests.cpp
@@ -408,3 +408,19 @@ void __declspec(naked) quest_change_kill_n_count() {
 		jmp eax
 	}
 }
+
+void __stdcall CheckPlayerSettings(T_PLAYER* player) {
+    const int id = player->id_ext.id;
+    const std::string name = player->name;
+
+    auto& settings = player_settings[id];
+    if (!settings || settings->player_name.empty()) {
+        // Settings are not set.
+        return;
+    }
+
+    if (settings->player_name != name) {
+        Printf("CheckPlayerSettings: clearing for player %d: name '%s' != '%s'", id, settings->player_name.c_str(), name.c_str());
+		settings.reset(new PlayerSettings());
+    }
+}

--- a/quests.h
+++ b/quests.h
@@ -4,10 +4,13 @@
 #include <string>
 #include <unordered_map>
 
+#include "utils.h"
+
 // Settings set by the player.
 struct PlayerSettings {
 	std::string quest_filter;
 	int quest_mob_count;
+	std::string player_name; // This is used to reset settings on relogin.
 };
 
 // Player settings. Player ID -> settings.
@@ -31,3 +34,8 @@ void InitializeMobNames();
 // Returns the state for "kill N monsters" quests for a given player.
 // Returns formatted user-readable strings.
 std::vector<std::string> QuestStateNMonsters(void* player);
+
+// Checks player name and the name in the existing player settings. If they are
+// different, it means that these settings were created by another player which
+// has already left the game, so we reset the settings.
+void __stdcall CheckPlayerSettings(T_PLAYER* player);

--- a/srvmgr.cpp
+++ b/srvmgr.cpp
@@ -32,7 +32,7 @@ char player_respawn[] = "Player %s respawned.";
 char enter_b1[] = "<cmd: enter to building>\n";
 char cancel_camp1[] = "Player %s cancelled camping.";
 char enter_shop1[] = "Player %s entered shop ID=%u from (%u, %u).";
-char enter_inn1[] = "Player %s entered inn ID=%u from (%u, %u).";
+char enter_inn1[] = "Player %s entered inn! ID=%u from (%u, %u).";
 char left_shop1[] = "Player %s left shop.";
 char left_inn1[] = "Player %s left inn.";
 char aErrPoint[] = "name: %s, error dst\n";
@@ -1798,6 +1798,12 @@ void _declspec(naked) enter_inn (void) {
 
         push    offset enter_inn1
         call    Printf
+
+        // When player enters the inn, we check if the quest filter needs to be reset.
+        mov eax, [ebp-0x0A8] // Unit.
+        push [eax + 0x14] // Player.
+        call CheckPlayerSettings
+
 e_i_sk:
         mov    ecx, [ebp-0x0A8]
         push    ecx

--- a/utils.h
+++ b/utils.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #pragma pack(1)
 #define _DWORD __int32
 #define _WORD __int16
@@ -59,7 +61,7 @@ struct  T_PLAYER
     _BYTE gap0[4];
     T_ID id_ext;
     _BYTE gap1[16];
-    _DWORD dword18;
+    const char* name;
     _BYTE gap2[8];
     _DWORD dword24;
     _DWORD dword28;
@@ -79,6 +81,8 @@ struct  T_PLAYER
     _DWORD dwordA58;
     _BYTE gap8[4];
     _DWORD dwordA60;
+    char gapA62[20];
+    const char* account_name;
 };
 
 struct __declspec(align(4)) T_UNIT


### PR DESCRIPTION
There are 16 slots for players, with IDs from 16 to 31 inclusive. If a player leaves the game and another player joins, the new player will reuse the same player ID as the first player. This leads to `#quest` filters being applied to wrong players.

I fix this by remembering the name of the player who created the filter and checking current player name when entering the inn. Different? Reset the filter.