### PR TITLE
Fix `#reborn` mistakes

### DIFF
--- a/cheat_codes_new.cpp
+++ b/cheat_codes_new.cpp
@@ -1110,8 +1110,8 @@ uint32_t GetDamageBonus(byte* unit)
     if (!unit) return 0;
 
     // check if this is human
-    uint32_t vtable_id = *(uint32_t*)unit;
-    if (vtable_id != 0x0060F0C8)
+    void* vtable_id = (void*)*(uint32_t*)unit;
+    if (vtable_id != A2_HUMAN_CLASS)
         return 0;
 
     uint32_t retval = 0;

--- a/partial_drop.cpp
+++ b/partial_drop.cpp
@@ -7,11 +7,11 @@
 
 void* (__cdecl *a2_operator_new)(int) = (void* (*)(int))0x005DDF54;
 
-T_LINKEDLIST* __stdcall create_new_item_list()
+T_INVENTORY_LIST* __stdcall create_new_item_list()
 {
     #define FUNC_ITEM_LIST_CONSTRUCTOR 0x00551C0A
-    T_LINKEDLIST* list = (T_LINKEDLIST*)a2_operator_new(0x24);
-    return (T_LINKEDLIST*)this_call(FUNC_ITEM_LIST_CONSTRUCTOR, list);
+    T_INVENTORY_LIST* list = (T_INVENTORY_LIST*)a2_operator_new(0x24);
+    return (T_INVENTORY_LIST*)this_call(FUNC_ITEM_LIST_CONSTRUCTOR, list);
 }
 
 float rnd()
@@ -30,17 +30,17 @@ float rnd_gaussian(float mu, float sigma)
 }
 
 
-void a2insert(T_LINKEDLIST * list, int pos, T_INVENTORY_ITEM* item)
+void a2insert(T_INVENTORY_LIST * list, int pos, T_INVENTORY_ITEM* item)
 {
     this_call(0x00551FC3, (void*)list, (void*)pos, (void*)item);
 }
 
-void a2insert(T_LINKEDLIST * list, T_INVENTORY_ITEM* item)
+void a2insert(T_INVENTORY_LIST * list, T_INVENTORY_ITEM* item)
 {
     a2insert(list, list->maxInd, item);
 }
 
-T_INVENTORY_ITEM* a2remove(T_LINKEDLIST * list, int pos, int n)
+T_INVENTORY_ITEM* a2remove(T_INVENTORY_LIST * list, int pos, int n)
 {
     return (T_INVENTORY_ITEM*)this_call(0x00552E42, (void*)list, (void*)pos, (void*)n);
 }
@@ -90,10 +90,10 @@ int getDropNum(int num, float probability)
         }
         return dropN;
 }
-void __stdcall drop_rnd_items(T_LINKEDLIST * item_list_src, T_LINKEDLIST * item_list_dst, float probability, int stopItemId)
+void __stdcall drop_rnd_items(T_INVENTORY_LIST * item_list_src, T_INVENTORY_LIST * item_list_dst, float probability, int stopItemId)
 {
-    T_SRV_LINKED_NODE* src_current = item_list_src->last_node;
-    int ind = item_list_src->size-1;
+    T_SRV_LINKED_NODE<T_INVENTORY_ITEM>* src_current = item_list_src->list.last_node;
+    int ind = item_list_src->list.size - 1;
     std::vector<IndNum> to_remove;
     while (src_current != NULL)
     {
@@ -137,9 +137,9 @@ bool __stdcall unit_has_weared_items(T_UNIT* unit)
     }
     return false;
 }
-void __stdcall drop_rnd_weared_items(T_UNIT* unit, T_LINKEDLIST * item_list_dst, float probability)
+void __stdcall drop_rnd_weared_items(T_UNIT* unit, T_INVENTORY_LIST * item_list_dst, float probability)
 {
-    if (unit->clazz != (void *)0x0060F0C8)
+    if (unit->clazz != A2_HUMAN_CLASS)
         return;        // unit does not support weared items
 
     for (int i = 1; i < 13; ++i )
@@ -187,7 +187,7 @@ void __stdcall drop_rnd_weared_items(T_UNIT* unit, T_LINKEDLIST * item_list_dst,
     }
 }
 
-int CopyInventoryToMap(T_UNIT *unit, T_LINKEDLIST *inventory, int a3, int a4)
+int CopyInventoryToMap(T_UNIT *unit, T_INVENTORY_LIST *inventory, int a3, int a4)
 {
     #define FUNC_COPY_INVENTORY_TO_MAP 0x0052D8D3
     return this_call(FUNC_COPY_INVENTORY_TO_MAP, (void *)unit, (void *)inventory, (void *)a3, (void *)a4);
@@ -199,9 +199,9 @@ const int T_UNIT_SKIP_DMG = 0xB203;
 int __stdcall nonStandardUnit(T_UNIT* unit, unsigned __int16 spec)
 {
     return false; //// <-- fastfix to prevent cheating
-    if (unit && unit->inventory && unit->inventory->size >= 1)
+    if (unit && unit->inventory && unit->inventory->list.size >= 1)
     {
-        T_SRV_LINKED_NODE* node = unit->inventory->first_node;
+        T_SRV_LINKED_NODE<T_INVENTORY_ITEM>* node = unit->inventory->list.first_node;
         for (int i = 0; i < 3; i++)
         {
             if (!node)
@@ -220,11 +220,11 @@ bool isPlayerUnit(T_UNIT* unit)
 }
 void __stdcall drop_partially(T_UNIT* unit, int a3, int a4)
 {
-    if (unit && unit->inventory && (unit->inventory->size > 0 || unit_has_weared_items(unit)))
+    if (unit && unit->inventory && (unit->inventory->list.size > 0 || unit_has_weared_items(unit)))
     {
         if (isPlayerUnit(unit))
         {
-            T_LINKEDLIST* bag = create_new_item_list();
+            T_INVENTORY_LIST* bag = create_new_item_list();
             if (nonStandardUnit(unit, T_UNIT_SKIP_DRP))
                 drop_rnd_items(unit->inventory, bag, Config::InventoryDropProbability, T_UNIT_SKIP_DRP_BAR);
             else

--- a/reborn_readiness.cpp
+++ b/reborn_readiness.cpp
@@ -25,6 +25,36 @@ const int32_t m = k * k;
 
 void CheckRebornReadiness(ServerIDType server_id, const PlayerInfo& player_info, unsigned char* p);
 
+// A2 server only stores the effective unit stats () Walk over all equipped
+void SubtractEquippedItems(A2Human* human, PlayerInfo& player_info) {
+    for (int i = -2; i < 13; ++i) {
+        T_INVENTORY_ITEM* item;
+
+        if (i == -2) {
+            item = human->unit.weapon;
+        } else if (i == -1) {
+            item = human->unit.shield;
+        } else {
+            item = human->dress[i];
+        }
+
+        if (item != nullptr) {
+            if (item->effects.size) {
+                auto* ptr = item->effects.first_node;
+                while (ptr != NULL) {
+                    if (ptr->value->effect_id == 3) {
+                        player_info.mind -= ptr->value->value1;
+                    } else if (ptr->value->effect_id == 4) {
+                        player_info.reaction -= ptr->value->value1;
+                    }
+
+                    ptr = ptr->next;
+                }
+            }
+        }
+    }
+}
+
 void RebornReadinessInfo(ServerIDType server_id, T_PLAYER* player, unsigned char* p) {
     T_UNIT* unit = player->current_unit;
 
@@ -34,7 +64,7 @@ void RebornReadinessInfo(ServerIDType server_id, T_PLAYER* player, unsigned char
 
     bool has_treasure = false;
     if (unit->inventory) {
-        T_SRV_LINKED_NODE* ptr = unit->inventory->first_node;
+        T_SRV_LINKED_NODE<T_INVENTORY_ITEM>* ptr = unit->inventory->list.first_node;
         while (ptr != NULL) {
             if (ptr->value->id == 3667) {
                 has_treasure = true;
@@ -54,6 +84,13 @@ void RebornReadinessInfo(ServerIDType server_id, T_PLAYER* player, unsigned char
     player_info.experience = unit->exp;
     player_info.monster_kills = player->monster_kills;
     player_info.deaths = player->deaths;
+
+    if (unit->clazz != A2_HUMAN_CLASS) {
+        zxmgr::SendMessage(p, "current unit is not a human: %x != %x", unit->clazz, A2_HUMAN_CLASS);
+    } else {
+        A2Human* human = reinterpret_cast<A2Human*>(unit);
+        SubtractEquippedItems(human, player_info);
+    }
 
     CheckRebornReadiness(server_id, player_info, p);
 }
@@ -99,7 +136,7 @@ int32_t ServerRequirementsMoney(ServerIDType server_id, const PlayerInfo& player
 
     // Hardcore and regular characters.
     switch (server_id) {
-        case EASY: return 50*k;
+        case EASY: return 30*k;
         case KIDS: return 300*k;
         case NIVAL: return 1500*k;
         case MEDIUM: return 7*m;
@@ -213,5 +250,4 @@ void CheckRebornReadiness(ServerIDType server_id, const PlayerInfo& player_info,
     for (std::vector<std::string>::const_iterator it = info_lines.cbegin(); it != info_lines.cend(); ++it) {
         zxmgr::SendMessage(p, "%s", it->c_str());
     }
-
 }

--- a/utils.h
+++ b/utils.h
@@ -7,10 +7,47 @@
 #define _WORD __int16
 #define _BYTE char
 
+const void* const A2_HUMAN_CLASS = reinterpret_cast<void*>(0x0060F0C8);
+
 struct T_ID
 {
   _WORD id;
   _WORD type;
+};
+
+template <typename T>
+struct __declspec(align(4)) T_SRV_LINKED_NODE
+{
+  T_SRV_LINKED_NODE *next;
+  T_SRV_LINKED_NODE *prev;
+  T* value;
+};
+
+template <typename T>
+struct __declspec(align(4)) T_LINKEDLIST
+{
+  _BYTE gap0[4];
+  T_SRV_LINKED_NODE<T> *first_node;
+  T_SRV_LINKED_NODE<T> *last_node;
+  __int32 size;
+  _DWORD dword10;
+  struct CPlex *pcplex14;
+  _DWORD dword18;
+};
+
+struct A2Effect {
+  uint8_t gap0[0x3c];
+  uint8_t effect_id; // Effect ID, same as in the editor.
+  uint8_t usage_type;
+  uint8_t gap3E[2];
+  uint8_t value1; // The main effect value.
+  uint8_t value2; // Optional second value. Used for damage, like "astral damage 3--5".
+};
+
+struct A2WorldEquip {
+  void* clazz;
+  const char* name;
+  // ...
 };
 
 struct T_INVENTORY_ITEM
@@ -18,14 +55,9 @@ struct T_INVENTORY_ITEM
   _DWORD dword0;
   _BYTE gap4[8];
   _WORD wordC;
-  _BYTE gapE[22];
-  _DWORD dword24;
-  _DWORD dword28;
-  _DWORD dword2C;
-  _DWORD dword30;
-  struct CPlex *pcplex34;
-  _DWORD dword38;
-  _DWORD dword3C;
+  _BYTE gapE[18];
+  T_LINKEDLIST<A2Effect> effects;
+  A2WorldEquip* world_equip;
   unsigned __int16 id;
   _WORD amount;
   _BYTE byte44;
@@ -39,24 +71,13 @@ struct T_INVENTORY_ITEM
   _DWORD dword54;
 };
 
-struct __declspec(align(4)) T_SRV_LINKED_NODE
+struct T_INVENTORY_LIST
 {
-  T_SRV_LINKED_NODE *next;
-  T_SRV_LINKED_NODE *prev;
-  T_INVENTORY_ITEM* value;
-};
-struct __declspec(align(4)) T_LINKEDLIST
-{
-  _BYTE gap0[4];
-  T_SRV_LINKED_NODE *first_node;
-  T_SRV_LINKED_NODE *last_node;
-  __int32 size;
-  _DWORD dword10;
-  struct CPlex *pcplex14;
-  _DWORD dword18;
+  T_LINKEDLIST<T_INVENTORY_ITEM> list;
   int maxInd;
   _DWORD dword20;
 };
+
 struct T_UNIT;
 struct  T_PLAYER
 {
@@ -125,7 +146,7 @@ struct __declspec(align(4)) T_UNIT
   _DWORD dword70;
   T_INVENTORY_ITEM *weapon;
   T_INVENTORY_ITEM *shield;
-  T_LINKEDLIST *inventory;
+  T_INVENTORY_LIST *inventory;
   const char* name2;
   uint16_t body;
   uint16_t reaction;
@@ -145,6 +166,13 @@ struct __declspec(align(4)) T_UNIT
   _WORD word14C;
   _BYTE gap9[82];
   _DWORD dword1A0;
+  _BYTE gap1A4[100];
+};
+
+struct A2Human {
+  T_UNIT unit;
+  T_INVENTORY_ITEM* dress[13];
+  // ...
 };
 
 #pragma pack()


### PR DESCRIPTION
1. Walk over all equipped items and subtract mind/reaction, because A2 only stores the effective stats.
2. Typo: gold requirements on EASY is 30k, not 50k

Here I'm also mapping several A2 structs with more fields. I don't want to use hardcoded offsets like `(char*)unit + 0x208` because it's brittle.