### PR TITLE
Solo: check relogin before stapling the cell

### DIFF
--- a/solo.cpp
+++ b/solo.cpp
@@ -352,11 +352,11 @@ extern "C" void __fastcall StapleCellOnMobKill(T_UNIT* killed_unit) {
         }
     }
 
+    CheckStaplesForReloggedCharacter(killed_unit->last_hit_by);
+
     staple_cells[position] = staple_with;
 
     Printf("[staple]: stapled cell %d with %d, there are %d staple cells now", position, staple_with, staple_cells.size());
-
-    CheckStaplesForReloggedCharacter(killed_unit->last_hit_by);
 }
 
 // Address: 00505e9c


### PR DESCRIPTION
Otherwise on the first mob killed we will remove the staple we've just created.

```
[11.02.2025 17:46:20.079] [solo] StapleCellOnMobKill: unit=0x4bcd218 (name=, id=24933), killed_by=0x4639608 (name=PLAYER_NAME, id=19)
[11.02.2025 17:46:20.080] [solo] FindSack at -31944
[11.02.2025 17:46:20.080] [solo] FindSack: found no sack at -31944
[11.02.2025 17:46:20.080] [staple]: stapled cell 33592 with 19, there are 51 staple cells now
[11.02.2025 17:46:20.080] [solo] CheckStaplesForReloggedCharacter: unit=0x4639608 (PLAYER_NAME, player_id=19)
[11.02.2025 17:46:20.080] [solo] CheckStaplesForReloggedCharacter: player 19 relogged, removed 3 staples
```