### PR TITLE
Add bonus damage dealt to players going on circles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(srvmgr SHARED srvmgr.def
     charcheck.cpp
     cheat_codes.cpp
     cheat_codes_new.cpp
+    circle.cpp
     common_new.cpp
     config_new.cpp
     crash_filter.cpp

--- a/circle.cpp
+++ b/circle.cpp
@@ -1,0 +1,165 @@
+#include "config_new.h"
+#include "utils.h"
+
+const char* UnitName(T_UNIT* unit) {
+    return unit ? unit->name : "?";
+}
+
+const char* PlayerName(T_UNIT* unit) {
+    return unit && unit->player ? unit->player->name : "??";
+}
+
+namespace circle {
+
+double Multiplier(int circle, ServerIDType server_id) {
+    switch (server_id) {
+        case EASY:      return 0.05 * circle;
+        case KIDS:      return 0.10 * circle;
+        case NIVAL:     return 0.15 * circle;
+        case MEDIUM:    return 0.20 * circle;
+        case HARD:      return 0.25 * circle;
+        case NIGHTMARE: return 0.30 * circle;
+        case QUEST_T1:  return 0.25 * circle;
+        case QUEST_T2:  return 0.20 * circle;
+        case QUEST_T3:  return 0.15 * circle;
+        case QUEST_T4:  return 0.10 * circle;
+        default:        return 0.0;
+    }
+}
+
+int Bonus(int circle, ServerIDType server_id) {
+    switch (server_id) {
+        case EASY:      return (circle + 1) / 2;
+        case KIDS:      return circle;
+        case NIVAL:     return circle;
+        case MEDIUM:    return circle;
+        case HARD:      return 2 * circle;
+        case NIGHTMARE: return 3 * circle;
+        case QUEST_T1:  return 4 * circle;
+        case QUEST_T2:  return 5 * circle;
+        case QUEST_T3:  return 6 * circle;
+        case QUEST_T4:  return 7 * circle;
+        default:        return 0;
+    }
+}
+
+// Increase damage to units that are going through circles.
+int IncreaseDamage(T_UNIT* attacker, T_UNIT* target, int damage) {
+    // Not a player's unit --- no changes.
+    if (!target || !target->player || target->player->unitType != 0) {
+        return damage;
+    }
+
+    // On-map effects are not modified.
+    if (!attacker || !attacker->player) {
+        return damage;
+    }
+
+    // PvP is untouched.
+    if (attacker->player->unitType == 0) {
+        return damage;
+    }
+
+    const char* name = target->player->name;
+
+    if (name == nullptr) {
+        return damage;
+    }
+
+    char maybe_circle = name[0];
+    if (name[0] == '_' || name[0] == '@') {
+        maybe_circle = name[1];
+    }
+
+    if ('1' >= maybe_circle || maybe_circle >= '9') {
+        return damage;
+    }
+
+    int circle_number = static_cast<int>(maybe_circle - '0');
+
+    double multiplier = 1 + Multiplier(circle_number, Config::ServerID);
+    int bonus = Bonus(circle_number, Config::ServerID);
+    int new_damage = static_cast<int>(damage * multiplier + bonus);
+    return new_damage;
+}
+
+}
+
+int ChangeDamageRegular(T_UNIT* attacker, T_UNIT* target, int damage) {
+    return circle::IncreaseDamage(attacker, target, damage);
+}
+
+int ChangeDamageSpecial(T_UNIT* attacker, T_UNIT* target, int damage) {
+    Printf("[circle/special] 0x%x -> 0x%x (%s/%s -> %s/%s) for %d", attacker, target, UnitName(attacker), PlayerName(attacker), UnitName(target), PlayerName(target), damage);
+    // No idea what the original logic is for. Not modfying the damage till we see some usage.
+    return damage;
+}
+
+int ChangeDamageMagic(T_UNIT* attacker, T_UNIT* target, int damage) {
+    return circle::IncreaseDamage(attacker, target, damage);
+}
+
+// Address: 00536d81
+void __declspec(naked) circle_damage_regular() {
+    __asm {
+        push DWORD PTR [ebp-0x1c] // Current damage.
+        push DWORD PTR [ebp-0x3c] // Attacker.
+        push DWORD PTR [ebp+0xc] // Target.
+        call ChangeDamageRegular
+
+        // Save new damage.
+        mov DWORD PTR [ebp-0x1c], eax
+
+        // Original logic.
+        mov ecx,DWORD PTR [ebp+0xc]
+        mov edx, 0
+        mov dl, BYTE PTR [ecx+0x4c]
+        add edx, 0x10
+
+        // Restore original instruction.
+        mov ebx, 0x00536d87
+        jmp ebx
+    }
+}
+
+// Address: 00536e1e
+void __declspec(naked) circle_damage_special() {
+    __asm {
+        // Original logic.
+        mov cl, BYTE PTR [edx+0x11]
+        add eax, ecx
+
+        push eax  // Current damage.
+        push DWORD PTR [ebp-0x3c] // Attacker.
+        push DWORD PTR [ebp+0xc] // Target.
+        call ChangeDamageSpecial
+
+        // Save new damage.
+        mov DWORD PTR [ebp-0x1c], eax
+
+        // Restore original instruction.
+        mov ebx, 0x00536e26
+        jmp ebx
+    }
+}
+
+// Address: 00536ed8
+void __declspec(naked) circle_damage_magic() {
+    __asm {
+        // Original logic.
+        mov dl, BYTE PTR [ecx+0x13]
+        add eax, edx
+
+        push eax  // Current damage.
+        push DWORD PTR [ebp-0x3c] // Attacker.
+        push DWORD PTR [ebp+0xc] // Target.
+        call ChangeDamageMagic
+
+        // Save new damage.
+        mov DWORD PTR [ebp-0x1c], eax
+
+        // Restore original instruction.
+        mov ebx, 0x00536ee0
+        jmp ebx
+    }
+}

--- a/crash_filter.cpp
+++ b/crash_filter.cpp
@@ -64,3 +64,17 @@ void SetExceptionFilter()
 {
     SetUnhandledExceptionFilter((LPTOP_LEVEL_EXCEPTION_FILTER)&exc_handler_run);
 }
+
+void PrintStackTrace(int ebp) {
+    log_format("BEGIN STACK TRACE: 0x%08Xh <= ", ebp);
+    unsigned long stebp = *(unsigned long*)(ebp);
+    while (true) {
+        if ((stebp & 3) || IsBadReadPtr((void*)stebp, 8)) {
+            break;
+        }
+
+        log_format2("%08Xh <= ", *(unsigned long*)(stebp+4));
+        stebp = *(unsigned long*)(stebp);
+    }
+    log_format2("END STACK TRACE\n");
+}

--- a/crash_filter.h
+++ b/crash_filter.h
@@ -1,3 +1,4 @@
 #pragma once
 
 void SetExceptionFilter();
+void PrintStackTrace(int ebp);

--- a/postbuild/server.dis
+++ b/postbuild/server.dis
@@ -273,3 +273,8 @@ CALL autobuff 005a8309 2 // invis other
 CALL autobuff 005a83fe 2 // invis self
 
 JMP summon 0053ac32
+
+// Increase damage to players going for circles.
+JMP circle_damage_regular 00536d81
+JMP circle_damage_special 00536e1e
+JMP circle_damage_magic 00536ed8

--- a/srvmgr.def
+++ b/srvmgr.def
@@ -186,3 +186,6 @@ drop_gold                               @326
 fix_scroll_burn                         @327
 autobuff                                @328
 summon                                  @329
+circle_damage_regular                   @330
+circle_damage_special                   @331
+circle_damage_magic                     @332


### PR DESCRIPTION
The damage is modified as `new_damage = old_damage * (1 + multiplier) + bonus`, where `multiplier` and `bonus` grow linearly with circle and change depending on the level.