### PR TITLE
Fix quest filters for necros and druids

### DIFF
--- a/cheat_codes_new.cpp
+++ b/cheat_codes_new.cpp
@@ -198,7 +198,7 @@ void ProcessCheat_Quest(byte* player, const std::string& args) {
 
 		InitializeMobNames();
 
-		for (auto mob = mob_names->begin(); mob != mob_names->end(); mob++) {
+		for (auto mob = mob_names_by_server_id_normed.begin(); mob != mob_names_by_server_id_normed.end(); mob++) {
 			if (mob->second.find(filter) != std::string::npos) {
 				matching_mobs++;
 			}

--- a/inn.cpp
+++ b/inn.cpp
@@ -6,8 +6,6 @@
 #include "quests.h"
 #include "config_new.h"
 
-std::unordered_map<int, std::string> mob_names_by_server_id;
-
 // Address in a2serv.exe: 50df19.
 // Original `ChooseRewardMob_0050df19` has `A2GameDataRes*` in ECX and `target_experience` on the stack.
 // `__fastcall` convention: last two arguments are passed in ECX and EDX, the rest on the stack.
@@ -101,10 +99,20 @@ void InitializeMobNames() {
 
 		const A2MonsterInfoData& d = *m.monsterData.data;
 
+		// Add necros share the same type_id=99. Same with druids (100) and catapults (101).
+		std::string name = m.name;
+		if (d.typeId == 99) {
+			name = "Necro";
+		} else if (d.typeId == 100) {
+			name = "Druid";
+		} else if (d.typeId == 101) {
+			name = "Catapult";
+		}
+
 		const int mob_type = d.face << 8 | d.typeId;
 
-		(*new_mob_names)[mob_type] = NormalizeMobName(m.name);
-		(*new_mob_names_raw)[mob_type] = m.name;
+		(*new_mob_names)[mob_type] = NormalizeMobName(name.c_str());
+		(*new_mob_names_raw)[mob_type] = name;
 
         mob_names_by_server_id[d.serverId] = m.name;
 	}
@@ -117,11 +125,15 @@ void InitializeMobNames() {
 		return;
 	}
 
+	for (auto it = mob_names_by_server_id.begin(); it != mob_names_by_server_id.end(); ++it) {
+		mob_names_by_server_id_normed[it->first] = NormalizeMobName(it->second.c_str());
+	}
+
 	// Most mobs of the first level don't have a suffix, which makes it
 	// impossible to choose only them with filters. For example, the ghost is
 	// `Ghost`, but a filter `Ghost` would also match `Ghost.2`.
 	// Let's append `.1` to each mob name that doesn't have a level.
-	for (auto it = new_mob_names->begin(); it != new_mob_names->end(); ++it) {
+	for (auto it = mob_names_by_server_id_normed.begin(); it != mob_names_by_server_id_normed.end(); ++it) {
 		const char mob_name_end = it->second.back();
 		if (mob_name_end < '0' || mob_name_end > '9') {
 			it->second += ".1";

--- a/quests.cpp
+++ b/quests.cpp
@@ -6,6 +6,8 @@
 
 std::unique_ptr<std::unordered_map<int, std::string>> mob_names;
 std::unique_ptr<std::unordered_map<int, std::string>> mob_names_raw;
+std::unordered_map<int, std::string> mob_names_by_server_id;
+std::unordered_map<int, std::string> mob_names_by_server_id_normed;
 std::unordered_map<short, std::unique_ptr<PlayerSettings>> player_settings;
 
 void InitializePlayerSettings() {
@@ -199,7 +201,7 @@ void __stdcall filter_out_existing_n_monsters_quests(A2Player* player, int32_t q
 
 		// Note: `mob_names` keys use the same format as the `quest_monster_type`.
 		const std::string& name_filter = player_settings[player->id_ext.id]->quest_filter;
-		if ((*mob_names.get())[quest_monster_type].find(name_filter) == std::string::npos) {
+		if ((*mob_names)[quest_monster_type].find(name_filter) == std::string::npos) {
 			return;
 		}
 	}
@@ -217,7 +219,7 @@ void __stdcall filter_out_existing_monster_quests(A2Player* player, A2Unit* ques
 		InitializeMobNames();
 
 		const std::string& name_filter = player_settings[player->id_ext.id]->quest_filter;
-		if ((*mob_names)[quest_monster_selected->face << 8 | quest_monster_selected->type_id].find(name_filter) == std::string::npos) {
+		if (mob_names_by_server_id_normed[quest_monster_selected->server_id].find(name_filter) == std::string::npos) {
 			return;
 		}
 	}
@@ -235,7 +237,7 @@ bool __stdcall filter_out_existing_group_quests(A2Player* player, A2Group* group
 		InitializeMobNames();
 
 		const std::string& name_filter = player_settings[player->id_ext.id]->quest_filter;
-		if ((*mob_names)[unit->face << 8 | unit->type_id].find(name_filter) == std::string::npos) {
+		if (mob_names_by_server_id_normed[unit->server_id].find(name_filter) == std::string::npos) {
 			return true; // Retry with the next unit in group.
 		}
 	}

--- a/quests.h
+++ b/quests.h
@@ -25,6 +25,7 @@ void InitializePlayerSettings();
 extern std::unique_ptr<std::unordered_map<int, std::string>> mob_names;
 extern std::unique_ptr<std::unordered_map<int, std::string>> mob_names_raw;
 extern std::unordered_map<int, std::string> mob_names_by_server_id;
+extern std::unordered_map<int, std::string> mob_names_by_server_id_normed;
 
 // Normalizes mob name by lowercasing the string and replacing all dashes with underscores.
 std::string NormalizeMobName(const char* name);


### PR DESCRIPTION
All necros share the same type_id = 99, same with druids (100) and catapults (101). Let's filter only "kill n mobs" quests with the weird mob identifier based on face and `type_id`, and all in other cases we have a pointer to a unit, so we can use a more stable `server_id`.