### PR TITLE
Reapply "Skip potion reward in the inn at nightmare+"

### DIFF
--- a/postbuild/server.dis
+++ b/postbuild/server.dis
@@ -288,3 +288,4 @@ JMP unsummon_unit 00557985
 
 JMP skip_experience_reward 005666c1
 JMP inn_scrolls_reward 00565b27
+JMP skip_potion_reward 005660c8

--- a/quests.cpp
+++ b/quests.cpp
@@ -435,3 +435,28 @@ void __declspec(naked) inn_scrolls_reward() {
         jmp ebx
     }
 }
+
+bool SkipPotionReward() {
+    return Config::ServerID >= NIGHTMARE;
+}
+
+// Address: 005660c8
+void __declspec(naked) skip_potion_reward() {
+    __asm {
+        call SkipPotionReward
+
+        test al, al
+        jnz skip
+
+        // Original instruction.
+        mov edx, DWORD PTR [ebp+0x8]
+        mov eax, DWORD PTR [edx+0x38]
+
+        mov ebx, 0x005660ce
+        jmp ebx
+
+    skip:
+        mov ebx, 0x0056661c
+        jmp ebx
+    }
+}

--- a/srvmgr.def
+++ b/srvmgr.def
@@ -193,3 +193,4 @@ dont_eat_bad_food                       @333
 unsummon_unit                           @334
 skip_experience_reward                  @335
 inn_scrolls_reward                      @336
+skip_potion_reward                      @337


### PR DESCRIPTION
This reverts commit aae1ba7a76bb053badf10d6259eca69bc68f212d.

Fix: `cmp eax, 0` compares 4-byte register, but `SkipPotionReward` sets only `al`, a 1-byte register. The function never touches the full `eax`, so its three leftmost bytes are left with garbage values from previous instructions, and they're unlikely 0.