### PR TITLE
Prevent self-attacks from setting `last_hit_by`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library(srvmgr SHARED srvmgr.def
     srvmgr.cpp
     srvmgr_new.cpp
     startup.cpp
+    suicide.cpp
     summon.cpp
     this_call.cpp
     thresholds.cpp

--- a/a2types.h
+++ b/a2types.h
@@ -240,7 +240,16 @@ struct A2UnitEye {
 
 struct A2Spell {
     void* vtable;
-    // ...
+    void* spell_info;
+    uint8_t spell_id;
+    uint8_t max_range;
+    uint8_t is_defensive;
+    uint8_t field5_0xb;
+    uint16_t mana_cost;
+    uint8_t damage_min;
+    uint8_t damage_spread;
+    uint16_t spell_power;
+    uint8_t field7_0x12[2];
 };
 
 struct A2SpellBook {
@@ -264,7 +273,7 @@ struct A2HitInfo { // UnitToHit in Ghidra.
     uint8_t staff_damage_spread;
     uint8_t damage_min;
     uint8_t damage_spread;
-    uint8_t magic_damage_type;
+    uint8_t spell_id;
 };
 
 struct A2Protections {
@@ -308,7 +317,9 @@ struct A2Unit {
     int8_t gap2[4];
     A2MonsterInfo* monster_info;
     A2Unit* last_hit_by;
-    int8_t gap4[6];
+    int8_t gap4[4];
+    int8_t last_hit_spell;
+    int8_t token_size;
     int8_t byte4A;
     int8_t face;
     int8_t unit_attrs;

--- a/postbuild/server.dis
+++ b/postbuild/server.dis
@@ -289,3 +289,8 @@ JMP unsummon_unit 00557985
 JMP skip_experience_reward 005666c1
 JMP inn_scrolls_reward 00565b27
 JMP skip_potion_reward 005660c8
+
+JMP prevent_suicide_regular 005370ed
+JMP prevent_suicide_drain_life 0053a7cc
+JMP prevent_suicide_point_effect 0053766c
+JMP prevent_suicide_area_effect 00538473

--- a/srvmgr.def
+++ b/srvmgr.def
@@ -194,3 +194,7 @@ unsummon_unit                           @334
 skip_experience_reward                  @335
 inn_scrolls_reward                      @336
 skip_potion_reward                      @337
+prevent_suicide_regular                 @338
+prevent_suicide_drain_life              @339
+prevent_suicide_point_effect            @340
+prevent_suicide_area_effect             @341

--- a/suicide.cpp
+++ b/suicide.cpp
@@ -1,0 +1,96 @@
+#include "a2types.h"
+
+void __fastcall PreventSuicideRegular(A2Unit* unit, A2Unit* attacker, A2HitInfo* hit_info) {
+    if (unit != attacker) {
+        unit->last_hit_by = attacker;
+
+        if (IsWarrior(attacker)) {
+            unit->last_hit_spell = 0;
+        } else if (hit_info) {
+            unit->last_hit_spell = hit_info->spell_id;
+        }
+    }
+}
+
+// Address: 005370ed.
+void __declspec(naked) prevent_suicide_regular() {
+    __asm {
+        mov ecx, DWORD PTR [ebp+0x8]  // Hit info
+        push ecx
+        mov ecx, DWORD PTR[ebp-0x3c]  // Target
+        mov edx, DWORD PTR[ebp+0xc]  // Attacker
+        call PreventSuicideRegular
+
+        mov eax, 0x00537126
+        jmp eax
+    }
+}
+
+void __fastcall PreventSuicideDrainLife(A2Unit* unit, A2Unit* attacker, A2Spell* spell) {
+    if (unit != attacker) {
+        unit->last_hit_by = attacker;
+        unit->last_hit_spell = spell->spell_id;
+    }
+}
+
+// Address: 0053a7cc.
+void __declspec(naked) prevent_suicide_drain_life() {
+    __asm {
+        mov ecx, DWORD PTR [ebp-0x2fc] // Spell
+        push ecx
+        mov ecx, DWORD PTR[ebp-0x5c]  // Target
+        mov edx, DWORD PTR[ebp+0x8]  // Attacker
+        call PreventSuicideDrainLife
+
+        mov ecx, 0x0053a7e4
+        jmp ecx
+    }
+}
+
+void __fastcall PreventSuicidePointEffect(A2Unit* unit, A2Unit* attacker, uint8_t spell_id) {
+    if (unit != attacker) {
+        unit->last_hit_by = attacker;
+        unit->last_hit_spell = spell_id;
+    }
+}
+
+// Address: 0053766c.
+void __declspec(naked) prevent_suicide_point_effect() {
+    __asm {
+        mov edx, DWORD PTR [ebp-0xc]  // Point effect
+        mov ecx, DWORD PTR [edx+0x4c]  // Its effect (maybe it's A2Effect*, not sure)
+        mov cl, BYTE PTR [ecx+0xc]  // Spell ID
+        push ecx
+
+        mov ecx, DWORD PTR[ebp-0x4]  // Target
+        mov edx, DWORD PTR[edx+0x3c]  // Point effect caster
+        call PreventSuicidePointEffect
+
+        mov eax, 0x00537687
+        jmp eax
+    }
+}
+
+void __fastcall PreventSuicideAreaEffect(A2Unit* unit, A2Unit* attacker, uint8_t spell_id) {
+    if (unit != attacker) {
+        unit->last_hit_by = attacker;
+        unit->last_hit_spell = spell_id;
+    }
+}
+
+// Address: 00538473.
+void __declspec(naked) prevent_suicide_area_effect() {
+    __asm {
+        mov edx, DWORD PTR[ebp-0x78]  // Area effect
+        mov ecx, DWORD PTR[edx+0x48]  // Its effect (maybe it's A2Effect*, not sure)
+        mov cl, BYTE PTR[ecx+0xc]  // Spell ID
+        push ecx
+
+        mov ecx, DWORD PTR[ebp+0x8]  // Target
+        mov edx, DWORD PTR[edx+0x3c]  // Effect caster
+        call PreventSuicideAreaEffect
+
+        mov edx, 0x0053849a
+        jmp edx
+    }
+}


### PR DESCRIPTION
This way, if the mob kills itself with a fireball or other area effect, the kill will be given to the character that hit it last.

Now the demons won't fail you the quest!