### PR TITLE
Add an option to restart the server on map change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(srvmgr SHARED srvmgr.def
     scanrange_check.cpp
     screenshots.cpp
     scroll_burn.cpp
+    server_state.cpp
     shared.cpp
     shops.cpp
     solo.cpp

--- a/a2types.h
+++ b/a2types.h
@@ -367,8 +367,8 @@ struct A2Unit {
     int8_t gap5[3];
     int32_t state;
     int32_t some_state;
-    void *pcobject58;
-    void *pcobject5C;
+    int32_t some_state2;
+    A2Unit *cast_target;
     int8_t byte60;
     int8_t byte61;
     int8_t gap6[2];

--- a/cheat_codes_new.cpp
+++ b/cheat_codes_new.cpp
@@ -782,7 +782,7 @@ void RunCommand(byte* _this, A2Player* player, const char* ccommand, uint32_t ri
         }
     }
 
-    if (true || rights & GMF_CMD_SET)
+    if (rights & GMF_CMD_SET)
     {
         if (rawcmd == "#nextmap")
         {

--- a/config_new.cpp
+++ b/config_new.cpp
@@ -2,6 +2,7 @@
 #include "lib\utils.hpp"
 #include "srvmgrdef.h"
 #include "cheat_codes_new.h"
+#include "server_state.h"
 
 #include <algorithm>
 #include <fstream>
@@ -167,6 +168,9 @@ namespace Config
     bool server_rotate_maps = true;
     bool shuffle_maps = true;
 
+    // Server will restart right after changing the map. Enabling together with `shuffle_maps` doesn't make much sense.
+    bool server_restart_on_map_change = false;
+
     // If these settings are set to true, it will forbid a player from taking several quests for the same monster, group or monster type.
     bool AllowOnlyOneQuest_KillNMonsters = false;
     bool AllowOnlyOneQuest_KillTheMonster = false;
@@ -191,6 +195,8 @@ float ReadFloatParameter(std::string value, float MinValue, float MaxValue)
 
 int ReadConfig(const char* filename)
 {
+    Printf("Reading config from '%s'. Command line: %s\n", GetCommandLineA());
+
     if(!Config::Includes.size()) // root config
     {
         // set defaults
@@ -345,6 +351,11 @@ int ReadConfig(const char* filename)
                         return lnid;
                     }
                     Config::shuffle_maps = StrToBool(value);
+                } else if (parameter == "server_restart_on_map_change") {
+                    if (!CheckBool(value)) {
+                        return lnid;
+                    }
+                    Config::server_restart_on_map_change = StrToBool(value);
                 }
                 else if(parameter == "description")
                 {
@@ -717,7 +728,9 @@ int ReadConfig(const char* filename)
             {
                 std::string m_filename = parameter;
                 uint32_t m_time = 2147483647;
-                if(value.length()) m_time = (uint32_t)(StrToFloat(value) * 60.0);
+                if (value.length()) {
+                    m_time = static_cast<uint32_t>(StrToFloat(value) * 60.0);
+                }
                 maps.emplace_back(std::move(m_filename), m_time);
             }
             else
@@ -738,10 +751,18 @@ int ReadConfig(const char* filename)
 
     f_cfg.close();
 
+    server_state.Load();
+
     if (Config::shuffle_maps) {
         auto device = std::random_device{};
         std::mt19937 generator(device());
         std::shuffle(maps.begin(), maps.end(), generator);
+    }
+
+    if (Config::server_restart_on_map_change) {
+        Printf("Setting map index to %d from server state", server_state.map_index);
+        int* a2_map_index = reinterpret_cast<int*>(0x006d1634);
+        *a2_map_index = server_state.map_index;
     }
 
     for (auto& map_and_time: maps) {

--- a/config_new.h
+++ b/config_new.h
@@ -86,6 +86,7 @@ namespace Config
     extern int16_t max_pvp_dmg;
     extern float shop_potions_factor;
     extern bool server_rotate_maps;
+    extern bool server_restart_on_map_change;
 
     extern bool AllowOnlyOneQuest_KillNMonsters;
     extern bool AllowOnlyOneQuest_KillTheMonster;

--- a/map_rotation.cpp
+++ b/map_rotation.cpp
@@ -1,35 +1,77 @@
+#include "a2types.h"
 #include "config_new.h"
-#include <stdlib.h>
 #include "lib\utils.hpp"
+#include "server_state.h"
 #include "this_call.h"
 
-void stop_server()
-{
+#include <cstdlib>
+#include <windows.h>
+
+void stop_server() {
     exit(0);
 }
 
-void __stdcall reset_map_counter()
-{
-    if (Config::server_rotate_maps)
-    {
-        Printf("Rolling maps");
-        int *server_map_index = (int *)(void *)0x006D1634;
-        *server_map_index = 0;
+void RestartProcess() {
+    // Get full path and command line of the current executable.
+    WCHAR path[MAX_PATH];
+    GetModuleFileNameW(NULL, path, MAX_PATH);
+
+    LPWSTR args = GetCommandLineW();
+
+    STARTUPINFOW si = { sizeof(si) };
+    PROCESS_INFORMATION pi = { 0 };
+
+    Printf("Restarting server on map change...");
+
+    // Start a new process.
+    auto created = CreateProcessW(
+        path,       // Path to .exe
+        args,       // Full command line with arguments
+        NULL, NULL, // Process/thread security
+        FALSE,      // Do not inherit handles
+        0,          // Creation flags
+        NULL, NULL, // Environment + current directory
+        &si, &pi    // Startup info / process info
+    );
+
+    if (created) {
+        Printf("Restarting server: new instance created successfully, cleaning up current process");
+
+        CloseHandle(pi.hProcess);
+        CloseHandle(pi.hThread);
+
+        ExitProcess(0);
+    } else {
+        Printf("Restarting server: failed to create new process, error %d. Retaining the current process", GetLastError());
     }
-    else
-    {
+}
+
+void MapRotation() {
+    const auto* map_times = (A2Array<int32_t>*)0x006d1618;
+    const int map_index = *(int *)0x006d1634;
+
+    Printf("Rolling maps, new index: %d out of %d", map_index, map_times->size);
+
+    server_state.map_index = map_index;
+    server_state.Save();
+
+    if (Config::server_restart_on_map_change) {
+        RestartProcess();
+        return;
+    }
+
+    if (!Config::server_rotate_maps && map_index == 0) {
         Printf("Stopping server after the last map");
         stop_server();
     }
 }
 
-int __declspec(naked) imp_reset_map_counter()
-{ 
-    __asm
-    {
-        mov        edx, reset_map_counter
-        call    edx
+// Address: 0048aba4
+int __declspec(naked) map_rotation() { 
+    __asm {
+        call MapRotation
         ret
+        // Original instruction is unused.
     }
 }
 

--- a/postbuild/server.dis
+++ b/postbuild/server.dis
@@ -212,7 +212,10 @@ CALL imp_increase_potions_in_shops 0054DAFC  // increase number of potions in sh
 
 CALL imp_inn_item_upgrade_failed 0056154E 149 // handles a situation when player upgrades an item in the inn, but does not have the original item on. 149 NOPs to override till 005615E9
 
-CAll imp_reset_map_counter 0048AB79 4 // checks if it needs to exit after the last map
+// Map rotation:
+// - terminates the process after the last map if `ServerRotateMaps` is off,
+// - restarts the server if `server_restart_on_map_change` is set.
+CALL map_rotation 0048aba4 1
 
 CALL imp_limit_magic_resist_wrapper 00532243 2 // limits magic resistance per class
 

--- a/server_state.cpp
+++ b/server_state.cpp
@@ -1,0 +1,42 @@
+#include "server_state.h"
+
+#include "lib/utils.hpp"
+
+#include <fstream>
+
+ServerState server_state;
+
+const char* server_state_filename = "server_state.dat";
+
+ServerState::ServerState() : map_index(0) {
+}
+
+bool ServerState::Save() {
+    std::ofstream f(server_state_filename, std::ios::out | std::ios::trunc);
+    if (!f) {
+        Printf("[server_state] save: failed to open '%s' for writing: %s", server_state_filename, std::strerror(errno));
+        return false;
+    }
+    f << map_index;
+    f.close();
+    if (!f) {
+        Printf("[server_state] save: failed to write to '%s': %s", server_state_filename, std::strerror(errno));
+        return false;
+    }
+    return true;
+}
+
+bool ServerState::Load() {
+    std::ifstream f(server_state_filename, std::ios::in);
+    if (!f) {
+        Printf("[server_state] load: failed to open '%s' for reading: %s", server_state_filename, std::strerror(errno));
+        return false;
+    }
+    f >> map_index;
+    f.close();
+    if (!f) {
+        Printf("[server_state] load: failed to read from '%s': %s", server_state_filename, std::strerror(errno));
+        return false;
+    }
+    return true;
+}

--- a/server_state.h
+++ b/server_state.h
@@ -1,0 +1,12 @@
+#pragma once
+
+struct ServerState {
+    int map_index;
+
+    ServerState();
+
+    bool Save();
+    bool Load();
+};
+
+extern ServerState server_state;

--- a/srvmgr.def
+++ b/srvmgr.def
@@ -154,7 +154,7 @@ imp_inn_quest_roll_interval					@206
 imp_distance_bug_fix						@208
 imp_increase_potions_in_shops   			@209
 imp_inn_item_upgrade_failed   				@210
-imp_reset_map_counter   					@211
+map_rotation                                @211
 imp_limit_magic_resist_wrapper   			@212
 remove_existing_n_monters_quests_wrapper	@213
 remove_existing_monster_quests_wrapper		@214


### PR DESCRIPTION
Controlled by `server_restart_on_map_change` in the config. Default off. This is likely to improve server stability, as we'll be flushing all the memory leaks away.

Saves the current map index to `server_state.dat` before restarting, and reads it back on startup. We can add more stuff to the persisted server state later (like players' autobuff settings or quest filters).