### PR TITLE
Introduce a type-safe logger

### DIFF
--- a/log.h
+++ b/log.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <sstream>
+#include <string>
+
+void LogString(std::string s); // Defined in utils.cpp
+
+// Logger gathers the message parts in a string stream and the destructor logs the accumulated message.
+// Automatically prepends a timestamp and appends a newline (via `LogString`, actually).
+// Sample usage: Log() << "Hello, " << 42 << "!";
+// Equivalent to `log_format("Hello, %d!", 42)` but with stream syntax.
+class Log {
+public:
+    explicit Log() : buffer(std::ostringstream{}) {
+    }
+
+    template<typename T>
+    Log& operator<<(const T& v) {
+        buffer << v;
+        return *this;
+    }
+
+    ~Log() {
+        LogString(buffer.str());
+    }
+
+private:
+    std::ostringstream buffer;
+};

--- a/map_rotation.cpp
+++ b/map_rotation.cpp
@@ -1,6 +1,7 @@
 #include "a2types.h"
 #include "config_new.h"
 #include "lib\utils.hpp"
+#include "log.h"
 #include "server_state.h"
 #include "this_call.h"
 
@@ -21,7 +22,7 @@ void RestartProcess() {
     STARTUPINFOW si = { sizeof(si) };
     PROCESS_INFORMATION pi = { 0 };
 
-    Printf("Restarting server on map change...");
+    Log() << "Restarting server on map change...";
 
     // Start a new process.
     auto created = CreateProcessW(
@@ -35,14 +36,14 @@ void RestartProcess() {
     );
 
     if (created) {
-        Printf("Restarting server: new instance created successfully, cleaning up current process");
+        Log() << "Restarting server: new instance created successfully, cleaning up current process";
 
         CloseHandle(pi.hProcess);
         CloseHandle(pi.hThread);
 
         ExitProcess(0);
     } else {
-        Printf("Restarting server: failed to create new process, error %d. Retaining the current process", GetLastError());
+        Log() << "Restarting server: failed to create new process, error " << GetLastError() << ". Retaining the current process";
     }
 }
 
@@ -50,7 +51,7 @@ void MapRotation() {
     const auto* map_times = (A2Array<int32_t>*)0x006d1618;
     const int map_index = *(int *)0x006d1634;
 
-    Printf("Rolling maps, new index: %d out of %d", map_index, map_times->size);
+    Log() << "Rolling maps, new index: " << map_index << " out of " << map_times->size;
 
     server_state.map_index = map_index;
     server_state.Save();
@@ -61,7 +62,7 @@ void MapRotation() {
     }
 
     if (!Config::server_rotate_maps && map_index == 0) {
-        Printf("Stopping server after the last map");
+        Log() << "Stopping server after the last map";
         stop_server();
     }
 }

--- a/utils.cpp
+++ b/utils.cpp
@@ -32,6 +32,17 @@ void __stdcall log_format(char *s, ...){///TESTED100%, STDCALL
     }
 }
 
+void LogString(std::string s) {
+    SYSTEMTIME tm;
+    GetLocalTime(&tm);
+    to_encoding(s);
+    FILE *fp = fopen(Config::LogFile.c_str(), "a");
+    if (fp) {
+        fprintf(fp, "[%d.%.2d.%.4d %d:%.2d:%.2d.%.3d] %s\n", tm.wDay, tm.wMonth, tm.wYear, tm.wHour, tm.wMinute, tm.wSecond, tm.wMilliseconds, s.c_str());
+        fclose(fp);
+    }
+}
+
 void __stdcall log_format2(char *s, ...){///TESTED100%, STDCALL
     char line[BUF_MAX];
     va_list va;


### PR DESCRIPTION
I'm tired of `Printf`/`log_format` blowing up the server due to wrong arguments.

Switch map_rotation.cpp to use the new logger as a proof of concept. Replacing all usages of `Printf`/`log_format` is optional.