### PR TITLE
Default diplomacy

### DIFF
--- a/a2objects.h
+++ b/a2objects.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "a2types.h"
+
+namespace a2 {
+
+inline A2World* World() {
+    return *reinterpret_cast<A2World**>(0x6A8B8C);
+}
+
+} // namespace a2

--- a/a2types.h
+++ b/a2types.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 
 const void* const A2_CLASS_HUMAN = (void*)0x0060F0C8;
@@ -495,6 +496,12 @@ struct A2GameDataRes {
     char whatever[0x8c];
     A2Array<A2MonsterInfo> monsters;
 };
+
+struct A2World {
+    uint8_t _gap0[0xA8C4];
+    uint8_t diplomacy[0x46][0x46];
+};
+static_assert(offsetof(A2World, diplomacy) == 0xA8C4, "A2World diplomacy offset must be 0xA8C4");
 
 
 bool IsWarrior(const A2Unit* unit);

--- a/cheat_codes_new.cpp
+++ b/cheat_codes_new.cpp
@@ -1,22 +1,26 @@
 #include "cheat_codes_new.h"
-#include "srvmgrdef.h"
-#include "lib\utils.hpp"
-#include "pvm2.h"
-#include "config_new.h"
-#include "protolayer_hat.h"
-#include "srvmgr.h"
+
+#include <cmath>
 #include <fstream>
-#include "zxmgr.h"
-#include "player_info.h"
+
+#include "a2objects.h"
+#include "a2types.h"
+#include "config_new.h"
+#include "lib\utils.hpp"
+#include "log.h"
 #include "pktmgr.h"
-#include "reborn_readiness.hpp"
-#include <math.h>
+#include "player_info.h"
+#include "player_settings.h"
+#include "protolayer_hat.h"
+#include "pvm2.h"
 #include "quests.h"
+#include "reborn_readiness.hpp"
 #include "scanrange.h"
 #include "screenshots.h"
-#include "a2types.h"
-#include "player_settings.h"
 #include "server_state.h"
+#include "srvmgrdef.h"
+#include "srvmgr.h"
+#include "zxmgr.h"
 
 
 uint32_t ParseFlags(std::string string)
@@ -284,6 +288,76 @@ void ProcessCheat_Autobuff(A2Player* player, const std::string& args) {
     zxmgr::SendMessage(player, "'%s' does not match any spells. Autobuff mask left unchanged.", command.c_str());
 }
 
+std::string DescribeDiplomacy(int diplomacy) {
+    std::string description;
+
+    if (diplomacy & 1) {
+        description += "war";
+    }
+    if (diplomacy & 2) {
+        description += (description.empty() ? "" : "+");
+        description += "ally";
+    }
+    if (diplomacy & 4) {
+        description += (description.empty() ? "" : "+");
+        description += "silent";
+    }
+    if (diplomacy & 16) {
+        description += (description.empty() ? "" : "+");
+        description += "vision";
+    }
+
+    if (description.empty()) {
+        description = "nothing";
+    }
+
+    return description;        
+}
+
+void ProcessCheat_Diplomacy(A2Player* player, const std::string& args) {
+    auto* player_settings = settings::FindOrCreate(player->name);
+
+    std::string command = ToLower(Trim(args));
+
+    if (command.empty()) {
+        zxmgr::SendMessage(player, "Your default diplomacy is: %s", DescribeDiplomacy(player_settings->default_diplomacy).c_str());
+        return;
+    }
+
+    int new_diplomacy = 0;
+
+    if (CheckInt(command)) {
+        new_diplomacy = StrToInt(command) & 0x17;
+    } else {
+        auto parts = Explode(command, "+");
+        for (auto& part: parts) {
+            auto mode = Trim(part);
+            if (mode == "war") {
+                new_diplomacy |= 1;
+            } else if (mode == "ally") {
+                new_diplomacy |= 2;
+            } else if (mode == "silent") {
+                new_diplomacy |= 4;
+            } else if (mode == "vision") {
+                new_diplomacy |= 16;
+            } else if (mode == "nothing") {
+                // Pass.
+            } else {
+                zxmgr::SendMessage(player, "Unknown diplomacy mode '%s'. Supported values: nothing, war, ally, silent, vision. Example: 'ally+vision'.", mode.c_str());
+                return;
+            }
+        }
+    }
+
+    if (new_diplomacy & 2) {
+        new_diplomacy &= ~1; // Can't be ally and at war.
+    }
+
+    player_settings->default_diplomacy = new_diplomacy;
+    player_settings->last_modified = time(NULL);
+    zxmgr::SendMessage(player, "Default diplomacy set to: %s", DescribeDiplomacy(player_settings->default_diplomacy).c_str());
+}
+
 bool ProcessCheat_VoteMap(A2Player* player, const std::string& args) {
     if (Config::ServerID != ServerIDType::QUEST_T1) {
         return false;
@@ -473,6 +547,17 @@ void RunCommand(byte* _this, A2Player* player, const char* ccommand, uint32_t ri
         if (ProcessCheat_VoteMap(player, args)) {
             server_state.ThrottledSave(); // Map order has changed, let's try to save it.
         }
+        return;
+    }
+
+    if (rawcmd == "#diplomacy") {
+        ProcessCheat_Diplomacy(player, args);
+        server_state.ThrottledSave(); // Save diplomacy settings.
+        return;
+    }
+    if (rawcmd == "#fren") { // "fren" is an easter-egg alias for "#diplomacy ally+vision"
+        ProcessCheat_Diplomacy(player, "ally+vision");
+        server_state.ThrottledSave(); // Save diplomacy settings.
         return;
     }
 

--- a/player_settings.h
+++ b/player_settings.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <string>
 
@@ -9,14 +10,21 @@ namespace settings {
 struct PlayerSettings {
     // Quest filter string. If non-empty, the player will only get quests for matching mobs. Example: `skeleton.4`.
     std::string quest_filter;
+
     // Quest mob count. If > 0, the player will only get quests for this many mobs (if allowed by the inn).
-    int quest_mob_count;
+    int quest_mob_count = 0;
+
     // If bit N is 1, the spell N will not be cast during autobuff casts. Persisted to server state.
-    uint32_t autobuff_mask; 
+    uint32_t autobuff_mask = 0; 
+
     // The name of the map this player voted for.
     std::string map_vote;
+
+    // The default diplomacy level for a player. Bit mask of: 1 (enemy), 2 (ally), 4 (silent), 16 (vision).
+    int default_diplomacy = 0;
+
     // Timestamp of the last modification of these settings.
-    time_t last_modified;
+    time_t last_modified = 0;
 };
 
 PlayerSettings* Find(const char* player_name);

--- a/postbuild/server.dis
+++ b/postbuild/server.dis
@@ -71,7 +71,7 @@ JMP private_chat_3 5073B6 /// disable sending private message to players not on 
 //JMP ;exc_handler 6081F0 /// exception handler
 JMP adm_invis 51C901 /// admin invis
 JMP adm_dip 4FFD77 /// admin diplomacy: monsters_alliance
-JMP adm_dip_2 4FFEA6 /// admin diplomacy: players_alliance
+JMP new_player_diplomacy 4FFEA6 /// players alliance for GMs and default diplomacy
 JMP loading_map_bug 4F1D4A /// loading map bug
 JMP chat_crash_fix 50716D /// chat crash fix
 JMP packet_recvd 504ABC /// invalid packet crash fix

--- a/server_state.cpp
+++ b/server_state.cpp
@@ -31,10 +31,13 @@ bool ServerState::Save() {
     }
     f << '\n';
 
-    // Save player settings. We store only autobuff masks for now.
+    // Save player settings. We store only autobuff masks and default diplomacy for now.
     settings::ForEachReadonly([&f](const std::string& player_name, settings::PlayerSettings* ps) {
         if (ps->autobuff_mask != 0) {
             f << "player_settings_autobuff_mask " << player_name << ' ' << ps->last_modified << ' ' << ps->autobuff_mask << '\n';
+        }
+        if (ps->default_diplomacy != 0) {
+            f << "player_settings_default_diplomacy " << player_name << ' ' << ps->last_modified << ' ' << ps->default_diplomacy << '\n';
         }
     });
 
@@ -116,6 +119,25 @@ bool ServerState::Load() {
 
             auto* ps = settings::FindOrCreate(player_name.c_str());
             ps->autobuff_mask = mask;
+            ps->last_modified = last_modified;
+        } else if (section == "player_settings_default_diplomacy") {
+            std::string player_name;
+            time_t last_modified;
+            uint32_t mask;
+            f >> player_name >> last_modified >> mask;
+
+            if (!f) {
+                Printf("[server_state] load: failed to read player_settings_default_diplomacy from '%s': %s", server_state_filename, std::strerror(errno));
+                return false;
+            }
+
+            // Skip timestamps older than 1 week.
+            if (time(NULL) - last_modified > 7 * 24 * 3600) {
+                continue;
+            }
+
+            auto* ps = settings::FindOrCreate(player_name.c_str());
+            ps->default_diplomacy = mask;
             ps->last_modified = last_modified;
         } else {
             Printf("[server_state] load: unknown section '%s' in '%s'", section.c_str(), server_state_filename);

--- a/srvmgr.cpp
+++ b/srvmgr.cpp
@@ -15,10 +15,13 @@
 #include <ctime>
 
 #include "a2types.h"
-#include "player_info.h"
+#include "a2objects.h"
 #include "lib\utils.hpp"
 #include "lib\packet.hpp"
 #include "lib\socket.hpp"
+#include "log.h"
+#include "player_info.h"
+#include "player_settings.h"
 #include "srvmgr_new.h"
 #include "thresholds.h"
 #include "quests.h"
@@ -1375,111 +1378,88 @@ void _declspec(naked) loading_map_bug()
     }
 }
 
+bool __fastcall GMDiplomacyAI(A2Player* player, int ai_id) {
+    if ((player->flags & GMF_AI_ALLY) == GMF_AI_ALLY) {
+        a2::World()->diplomacy[player->id_ext.id][ai_id] = 2;
+        a2::World()->diplomacy[ai_id][player->id_ext.id] = 2;
+        return true;
+    }
+
+    return false;
+}
+
+// Address: 004FFD77
 void _declspec(naked) adm_dip(void) {
-    __asm {//004FFD77
-        mov    edx, [ebp+0x08] // player
-        mov    eax, [edx+14h]
-        shr    eax, 18h
-        cmp    al, 3Fh
-        jnz    a_d_c ///не админ, продолжаем
-        mov    eax, [edx+14h]
-        test    eax, 0x4000 /// monsters_alliance
-        jz    a_d_c
-        
-        mov    edx, [ebp+0x08] // player
-        movsx    edx, word ptr [edx + 4]
-        imul    edx, 46h
-        add    edx, dword ptr [ebp-0x58]
-        add    edx, 0xA8C4
-        mov    ecx, 0x6A8B8C
-        add    edx, dword ptr [ecx]
-        mov    byte ptr [edx], 0x2
+    __asm {
+        mov  ecx, dword ptr [ebp+8]    // Joining player
+        mov  edx, dword ptr [ebp-0x58] // Target AI player ID (cycles from 2 to 16)
 
-        mov    edx, dword ptr [ebp-0x58]
-        imul    edx, 46h
-        mov    eax, [ebp+0x08] // player
-        movsx    eax, word ptr [eax + 4]
-        add    edx, eax
-        add    edx, 0xA8C4
-        mov    ecx, 0x6A8B8C
-        add    edx, dword ptr [ecx]
-        mov    byte ptr [edx], 0x2
+        call GMDiplomacyAI
 
-        mov    edx, 0x4FFD68
-        jmp    edx
+        test al, al
+        jz   original
 
-a_d_c:
-        mov    edx, [ebp-0x058]
-        imul    edx, 46h
-        mov    eax, 0x004FFD7D
-        jmp    eax
+        mov  edx, 0x004FFD68
+        jmp  edx
+
+    original:
+        mov  edx, dword ptr [ebp-0x58]
+        imul edx, 0x46
+        mov  eax, 0x004FFD7D
+        jmp  eax
     }
 }
 
-void _declspec(naked) adm_dip_2(void) {
-    __asm {//004FFEA6
-            mov edx, dword ptr [ebp+0x08] // player
-          mov ecx, dword ptr [ebp-0x54]
-        //  movsx edx, word ptr [edx + 4]
-        //  movsx ecx, word ptr [ecx + 4]
-          cmp ecx, edx
-          jz a_d_2_n_a_2 /// себе - вид
-    /*__asm {//004FFEA6
-        mov    edx, [ebp+0x08] // player
-        cmp    edx, dword ptr [ebp-54]
-        jz    a_d_2_n_a_2 /// себе - вид*/
-        mov    eax, [edx+14h]
-        shr    eax, 18h
-        cmp    al, 3Fh
-        jnz    a_d_2_n_a /// не админ
-        mov    eax, [edx+14h]
-        test    eax, 0x10000 /// players_alliance
-        jz    a_d_2_n_a
-        jmp    adm_dip_2_set_dip
+inline bool GMPlayersAlly(A2Player* player) {
+    return (player->flags & GMF_PLAYERS_ALLY) == GMF_PLAYERS_ALLY;
+}
 
-a_d_2_n_a:    
-        mov    edx, dword ptr [ebp-0x54]
-        mov    eax, [edx+14h]
-        shr    eax, 18h
-        cmp    al, 3Fh
-        jnz    a_d_2_n_a_2 /// не админ
-        mov    eax, [edx+14h]
-        test    eax, 0x10000 /// players_alliance
-        jz    a_d_2_n_a_2
+bool __fastcall NewPlayerDiplomacy(A2Player* player, A2Player* other) {
+    if (player == other) {
+        return false;
+    }
 
-adm_dip_2_set_dip:
+    bool changed = false;
+    const auto* player_settings = settings::Find(player->name);
+    if (player_settings && player_settings->default_diplomacy) {
+        zxmgr::SetDiplomacy(player, other, player_settings->default_diplomacy);
+        changed = true;
+    }
 
-        mov    edx, [ebp+0x08] // player
-        movsx    edx, word ptr [edx + 4]
-        imul    edx, 46h
-        mov    eax, dword ptr [ebp-0x54]
-        movsx    eax, word ptr [eax + 4]
-        add    edx, eax
-        add    edx, 0xA8C4
-        mov    ecx, 0x6A8B8C
-        add    edx, dword ptr [ecx]
-        mov    byte ptr [edx], 0x2
+    const auto* other_settings = settings::Find(other->name);
+    if (other_settings && other_settings->default_diplomacy) {
+        zxmgr::SetDiplomacy(other, player, other_settings->default_diplomacy);
+        changed = true;
+    }
 
-        mov    edx, dword ptr [ebp-0x54]
-        movsx    edx, word ptr [edx + 4]
-        imul    edx, 46h
-        mov    eax, [ebp+0x08] // player
-        movsx    eax, word ptr [eax + 4]
-        add    edx, eax
-        add    edx, 0xA8C4
-        mov    ecx, 0x6A8B8C
-        add    edx, dword ptr [ecx]
-        mov    byte ptr [edx], 0x2
+    if (GMPlayersAlly(player) || GMPlayersAlly(other)) {
+        zxmgr::SetDiplomacy(player, other, 2);
+        zxmgr::SetDiplomacy(other, player, 2);
+        return true;
+    }
 
-        mov    edx, 0x4FFF09
-        jmp    edx
+    return changed;
+}
 
-a_d_2_n_a_2:    
+// Address: 004FFEA6
+void __declspec(naked) new_player_diplomacy() {
+    __asm {
+        mov  ecx, [ebp+8]     // Joining player
+        mov  edx, [ebp-0x54]  // Target (cycles through all non-AI players)
 
-        mov    edx, [ebp+0x08]
-        movsx    eax, word ptr [edx+4]
-        mov    edx, 0x4FFEAD
-        jmp    edx
+        call NewPlayerDiplomacy
+
+        test al, al
+        jz   original
+
+        mov  edx, 0x4FFF09
+        jmp  edx
+
+    original:
+        mov  edx, [ebp+8]
+        movsx eax, word ptr [edx+4]
+        mov  edx, 0x4FFEAD
+        jmp  edx
     }
 }
 

--- a/srvmgr.def
+++ b/srvmgr.def
@@ -37,7 +37,7 @@ private_chat_3		@34
 ;exc_handler		@35
 adm_invis		@36
 adm_dip			@37
-adm_dip_2		@38
+new_player_diplomacy        @38
 msgbox_am		@39
 loading_map_bug		@43
 chat_crash_fix		@44

--- a/srvmgr_new.cpp
+++ b/srvmgr_new.cpp
@@ -11,6 +11,7 @@
 #include "scanrange.h"
 #include "unit_info.h"
 #include "forbidden_items.h"
+#include "log.h"
 #include "multiplayer_shop.h"
 #include "solo.h"
 #include "player_settings.h"

--- a/utils.cpp
+++ b/utils.cpp
@@ -36,10 +36,10 @@ void LogString(std::string s) {
     SYSTEMTIME tm;
     GetLocalTime(&tm);
     to_encoding(s);
-    FILE *fp = fopen(Config::LogFile.c_str(), "a");
-    if (fp) {
-        fprintf(fp, "[%d.%.2d.%.4d %d:%.2d:%.2d.%.3d] %s\n", tm.wDay, tm.wMonth, tm.wYear, tm.wHour, tm.wMinute, tm.wSecond, tm.wMilliseconds, s.c_str());
-        fclose(fp);
+    if (Config::ServerStarted) {
+        print_log(&s[0]);
+    } else {
+        log_format("%s\n", s.c_str());
     }
 }
 

--- a/zxmgr.cpp
+++ b/zxmgr.cpp
@@ -1,4 +1,5 @@
 #include "a2types.h"
+#include "a2objects.h"
 #include "syslib.h"
 #include "zxmgr.h"
 #include "srvmgr.h"
@@ -1233,20 +1234,18 @@ ret_0:
         }
     }
 
-    uint8_t GetDiplomacy(A2Player* player1, A2Player* player2)
-    {
-        return *(uint8_t*)(*(uint32_t*)(0x006A8B8C) + 0x46 * player1->id_ext.id + 0xA8C4 + player2->id_ext.id);
+    uint8_t GetDiplomacy(A2Player* player1, A2Player* player2) {
+        return a2::World()->diplomacy[player1->id_ext.id][player2->id_ext.id];
     }
 
-    void SetDiplomacy(A2Player* player1, A2Player* player2, uint8_t diplomacy)
-    {
-        if (player1->unitType && (diplomacy & 0x10)) // vision won't work for AI players
+    void SetDiplomacy(A2Player* player1, A2Player* player2, uint8_t diplomacy) {
+        if (player1->unitType && (diplomacy & 0x10)) { // vision won't work for AI players
             diplomacy &= ~0x10;
+        }
 
-        *(uint8_t*)(*(uint32_t*)(0x006A8B8C) + 0x46 * player1->id_ext.id + 0xA8C4 + player2->id_ext.id) = diplomacy;
+        a2::World()->diplomacy[player1->id_ext.id][player2->id_ext.id] = diplomacy;
 
-        if (!player1->unitType && !player2->unitType && (diplomacy & 0x10))
-        {
+        if (!player1->unitType && !player2->unitType && (diplomacy & 0x10)) {
             // i don't know how's this related
             player2->diplomacy_32 |= player1->diplomacy_30; // update player2 to player1
             player1->diplomacy_32 |= player2->diplomacy_30; // update player1 to player2


### PR DESCRIPTION
1. Injections for GM diplomacy are rewritten in C++.
2. "GM auto-ally players" logic now also handles the default diplomacy for each player.
3. Players can set default diplomacy with `#diplomacy`. Examples: `#diplomacy ally+vision`, `#diplomacy war+silent`.
4. Default diplomacy is saved into the server state.